### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
 jobs:
   analyze:
     name: SonarQube Analysis


### PR DESCRIPTION
Potential fix for [https://github.com/sm-moshi/docshunter/security/code-scanning/20](https://github.com/sm-moshi/docshunter/security/code-scanning/20)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required. Based on the workflow steps, the following permissions are needed:
- `contents: read` for accessing the repository's contents.
- `actions: read` for interacting with GitHub Actions artifacts (e.g., downloading/uploading artifacts).
- `security-events: write` for the SonarQube scan, which may require updating code scanning alerts.

The `permissions` block will be added at the root level of the workflow to apply to all jobs. If any job requires additional permissions, they can be defined specifically for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
